### PR TITLE
pass parent to child mapping as config parameter

### DIFF
--- a/benchmarks/configs/infer_compositional_objects.py
+++ b/benchmarks/configs/infer_compositional_objects.py
@@ -38,6 +38,7 @@ from tbp.monty.frameworks.environments.logos_on_objs import (
     OBJECTS_WITH_LOGOS_LVL2,
     OBJECTS_WITH_LOGOS_LVL3,
     OBJECTS_WITH_LOGOS_LVL4,
+    PARENT_TO_CHILD_MAPPING,
 )
 from tbp.monty.frameworks.experiments import MontyObjectRecognitionExperiment
 from tbp.monty.frameworks.models.evidence_matching.learning_module import (
@@ -178,6 +179,7 @@ infer_comp_base_config = dict(
         object_init_sampler=PredefinedObjectInitializer(
             rotations=test_rotations_all,
         ),
+        parent_to_child_mapping=PARENT_TO_CHILD_MAPPING,
     ),
 )
 
@@ -204,6 +206,7 @@ infer_parts_with_part_models.update(
         object_init_sampler=PredefinedObjectInitializer(
             rotations=test_rotations_all,
         ),
+        parent_to_child_mapping=PARENT_TO_CHILD_MAPPING,
     ),
 )
 
@@ -229,6 +232,7 @@ infer_comp_lvl2_with_comp_models.update(
         object_init_sampler=PredefinedObjectInitializer(
             rotations=test_rotations_all,
         ),
+        parent_to_child_mapping=PARENT_TO_CHILD_MAPPING,
     ),
 )
 
@@ -246,6 +250,7 @@ infer_comp_lvl3_with_comp_models.update(
         object_init_sampler=PredefinedObjectInitializer(
             rotations=test_rotations_all,
         ),
+        parent_to_child_mapping=PARENT_TO_CHILD_MAPPING,
     ),
 )
 
@@ -262,6 +267,7 @@ infer_comp_lvl4_with_comp_models.update(
         object_init_sampler=PredefinedObjectInitializer(
             rotations=test_rotations_all,
         ),
+        parent_to_child_mapping=PARENT_TO_CHILD_MAPPING,
     ),
 )
 

--- a/src/tbp/monty/frameworks/config_utils/make_dataset_configs.py
+++ b/src/tbp/monty/frameworks/config_utils/make_dataset_configs.py
@@ -320,6 +320,7 @@ class RandomRotationObjectInitializer(DefaultObjectInitializer):
 class EnvironmentDataloaderPerObjectArgs:
     object_names: List
     object_init_sampler: Callable
+    parent_to_child_mapping: Dict = None
 
 
 @dataclass

--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -221,7 +221,14 @@ class EnvironmentDataLoaderPerObject(EnvironmentDataLoader):
     sampled from the same object list, can be added.
     """
 
-    def __init__(self, object_names, object_init_sampler, *args, **kwargs):
+    def __init__(
+        self,
+        object_names,
+        object_init_sampler,
+        parent_to_child_mapping=None,
+        *args,
+        **kwargs,
+    ):
         """Initialize dataloader.
 
         Args:
@@ -236,6 +243,8 @@ class EnvironmentDataLoaderPerObject(EnvironmentDataLoader):
             object_init_sampler: Function that returns dict with position, rotation,
                 and scale of objects when re-initializing. To keep configs
                 serializable, default is set to :class:`DefaultObjectInitializer`.
+            parent_to_child_mapping: dictionary mapping parent objects to their child
+                objects.
             *args: ?
             **kwargs: ?
 
@@ -274,6 +283,8 @@ class EnvironmentDataLoaderPerObject(EnvironmentDataLoader):
         self.episodes = 0
         self.epochs = 0
         self.primary_target = None
+        self.consistent_child_objects = None
+        self.parent_to_child_mapping = parent_to_child_mapping
 
     def pre_episode(self):
         super().pre_episode()
@@ -371,6 +382,16 @@ class EnvironmentDataLoaderPerObject(EnvironmentDataLoader):
             "semantic_id": self.semantic_label_to_id[self.object_names[idx]],
             **self.object_params,
         }
+        if self.parent_to_child_mapping is not None:
+            if self.primary_target["object"] in self.parent_to_child_mapping:
+                self.consistent_child_objects = self.parent_to_child_mapping[
+                    self.primary_target["object"]
+                ]
+            else:
+                logger.warning(
+                    f"target object {self.primary_target['object']} not in",
+                    " parent_to_child_mapping",
+                )
         logger.info(f"New primary target: {pformat(self.primary_target)}")
 
     def add_distractor_objects(

--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -315,7 +315,12 @@ class MontyExperiment:
         )
         # FIXME: 'target' attribute is specific to `EnvironmentDataLoaderPerObject`
         if isinstance(self.dataloader, EnvironmentDataLoaderPerObject):
-            args.update(target=self.dataloader.primary_target)
+            target = self.dataloader.primary_target
+            if target is not None:
+                target.update(
+                    consistent_child_objects=self.dataloader.consistent_child_objects
+                )
+            args.update(target=target)
         return args
 
     def init_loggers(self, logging_config: Dict[str, Any]) -> None:


### PR DESCRIPTION
passing the mapping as an optional dataloader parameter and treating it similar to the target object in the logger args.

This PR passes all unit tests, ruff checks, and replicates comp object results (https://wandb.ai/thousand-brains-project/Monty/runs/gji33szy)