### PR TITLE
Different supervision

### DIFF
--- a/benchmarks/configs/learn_compositional_objects.py
+++ b/benchmarks/configs/learn_compositional_objects.py
@@ -146,6 +146,9 @@ supervised_pre_training_flat_objects_wo_logos.update(
     experiment_args=ExperimentArgs(
         do_eval=False,
         n_train_epochs=len(train_rotations_all),
+        # only learn child objects in lm_0 at first so they can be used as input when
+        # LM_1 is learning.
+        supervised_lm_ids=["learning_module_0"],
     ),
     monty_config=TwoLMStackedMontyConfig(
         monty_args=MontyArgs(num_exploratory_steps=1000),
@@ -186,6 +189,7 @@ supervised_pre_training_logos_after_flat_objects.update(
         do_eval=False,
         n_train_epochs=len(LOGO_POSITIONS) * len(LOGO_ROTATIONS),
         show_sensor_output=False,
+        supervised_lm_ids=["learning_module_0"],
         model_name_or_path=os.path.join(
             fe_pretrain_dir,
             "supervised_pre_training_flat_objects_wo_logos/pretrained/",
@@ -220,6 +224,7 @@ supervised_pre_training_curved_objects_after_flat_and_logo.update(
     experiment_args=ExperimentArgs(
         do_eval=False,
         n_train_epochs=len(train_rotations_all),
+        supervised_lm_ids=["learning_module_0"],
         model_name_or_path=os.path.join(
             fe_pretrain_dir,
             "supervised_pre_training_logos_after_flat_objects/pretrained/",

--- a/src/tbp/monty/frameworks/environments/logos_on_objs.py
+++ b/src/tbp/monty/frameworks/environments/logos_on_objs.py
@@ -20,7 +20,9 @@ LOGOS = ["021_logo_tbp", "022_logo_numenta"]
 
 FLAT_OBJECTS_WITHOUT_LOGOS = ["001_cube", "006_disk"]
 
-OBJECTS_WITH_LOGOS_LVL1 = [
+# not including standalone logos since to simplify experiment setup (they can't be shown
+# in all orientations)
+OBJECTS_WITH_LOGOS_LVL1 = FLAT_OBJECTS_WITHOUT_LOGOS + [
     "002_cube_tbp_horz",
     "004_cube_numenta_horz",
     "007_disk_tbp_horz",
@@ -31,14 +33,18 @@ CURVED_OBJECTS_WITHOUT_LOGOS = ["011_cylinder", "016_sphere", "023_mug"]
 
 ALL_PART_OBJECTS = LOGOS + FLAT_OBJECTS_WITHOUT_LOGOS + CURVED_OBJECTS_WITHOUT_LOGOS
 
-OBJECTS_WITH_LOGOS_LVL2 = OBJECTS_WITH_LOGOS_LVL1 + [
-    "012_cylinder_tbp_horz",
-    "014_cylinder_numenta_horz",
-    "017_sphere_tbp_horz",
-    "019_sphere_numenta_horz",
-    "024_mug_tbp_horz",
-    "026_mug_numenta_horz",
-]
+OBJECTS_WITH_LOGOS_LVL2 = (
+    OBJECTS_WITH_LOGOS_LVL1
+    + CURVED_OBJECTS_WITHOUT_LOGOS
+    + [
+        "012_cylinder_tbp_horz",
+        "014_cylinder_numenta_horz",
+        "017_sphere_tbp_horz",
+        "019_sphere_numenta_horz",
+        "024_mug_tbp_horz",
+        "026_mug_numenta_horz",
+    ]
+)
 
 OBJECTS_WITH_LOGOS_LVL3 = OBJECTS_WITH_LOGOS_LVL2 + [
     "003_cube_tbp_vert",

--- a/src/tbp/monty/frameworks/environments/logos_on_objs.py
+++ b/src/tbp/monty/frameworks/environments/logos_on_objs.py
@@ -20,7 +20,7 @@ LOGOS = ["021_logo_tbp", "022_logo_numenta"]
 
 FLAT_OBJECTS_WITHOUT_LOGOS = ["001_cube", "006_disk"]
 
-# not including standalone logos since to simplify experiment setup (they can't be shown
+# not including standalone logos to simplify experiment setup (they can't be shown
 # in all orientations)
 OBJECTS_WITH_LOGOS_LVL1 = FLAT_OBJECTS_WITHOUT_LOGOS + [
     "002_cube_tbp_horz",

--- a/src/tbp/monty/frameworks/experiments/pretraining_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/pretraining_experiments.py
@@ -133,11 +133,13 @@ class MontySupervisedObjectPretrainingExperiment(MontyExperiment):
                     first_pos = self.sensor_pos[0]
                 else:
                     lm_offset = self.sensor_pos[i] - first_pos
-
-                    lm.buffer.stats["detected_location_rel_body"] += lm_offset
-                    # Rotate offset into model RF
-                    lm_offset_model_rf = lm.detected_rotation_r.apply(lm_offset)
-                    lm.buffer.stats["detected_location_on_model"] += lm_offset_model_rf
+                    if lm.detected_object is not None:
+                        lm.buffer.stats["detected_location_rel_body"] += lm_offset
+                        # Rotate offset into model RF
+                        lm_offset_model_rf = lm.detected_rotation_r.apply(lm_offset)
+                        lm.buffer.stats["detected_location_on_model"] += (
+                            lm_offset_model_rf
+                        )
 
         # Update the model in memory
         self.post_episode(num_steps)

--- a/src/tbp/monty/frameworks/models/evidence_matching/learning_module.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching/learning_module.py
@@ -1196,7 +1196,9 @@ class EvidenceGraphLM(GraphLM):
         # prediction error calculation and stats collection.
         graph_id = self.previous_mlh["graph_id"]
 
-        if graph_id == "no_observations_yet":
+        if graph_id in ["no_observations_yet", "new_object0"]:
+            # don't try to log prediction errors if there were no observations or LM
+            # detected no match.
             return
         graph_telemetry = self.hypotheses_updater_telemetry[graph_id]
         prediction_errors = []


### PR DESCRIPTION
This is the different supervision setup we discussed in the research meeting and technical meeting. Here we first supervise only the LLLM to learn the child objects (logos and objects independently). Then we supervise only the HLLM to learn all objects (compositional + child objects). This means that also the child objects learned in the HLLM will receive and store input from the LLLM.

Here are the graphs learned for Disk and Cube in the HLLM. You can see that it stores the cube ID (655) or disk ID (672) from the LLLM.
<img width="731" height="535" alt="Screenshot 2025-10-14 at 3 51 07 PM" src="https://github.com/user-attachments/assets/390bc3a1-2f8d-4dac-bf22-de44499e5aa9" />
<img width="725" height="529" alt="Screenshot 2025-10-14 at 3 51 20 PM" src="https://github.com/user-attachments/assets/dadadd1e-b4b0-4dd6-a7e3-2dee50746f22" />

Attached are some corresponding results: 
red: current main branch
purple: testing on child objects in addition to compositional objects (before `OBJECTS_WITH_LOGOS_LVL1` only contained the compositional objects. We don't necessarily have to do this but I think it may be more comprehensive)
pink: testing on models trained with the different supervision setup (i.e. all HLLM model contain object IDs from LLLM)
<img width="1784" height="183" alt="Screenshot 2025-10-14 at 3 56 55 PM" src="https://github.com/user-attachments/assets/4a5ba358-d7be-4940-85ac-4e6dcf573fad" />
<img width="933" height="274" alt="Screenshot 2025-10-14 at 3 55 56 PM" src="https://github.com/user-attachments/assets/ac959a80-21a8-4691-bc33-73ed40edbf9f" />

It looks worse when you look at the numbers but when looking at the csv stats, it looks mostly reasonable. Most of the confusions come from the HLLM not being able to distinguish the same shaped objects with the different logos. But all possible matches are the correct shape. This might be exacerbated with this new supervision setup since now also the objects without logos have LLLM info in their models and use that to update their evidence, making their evidence values more similar.
<img width="983" height="249" alt="Screenshot 2025-10-14 at 4 56 48 PM" src="https://github.com/user-attachments/assets/66beea54-5916-41c4-b4f5-23326f0467a5" />


